### PR TITLE
Agregar CRUD completo de Brand y Model con páginas Razor

### DIFF
--- a/Fuerza_G_Taller/Fuerza_G_Taller.csproj
+++ b/Fuerza_G_Taller/Fuerza_G_Taller.csproj
@@ -11,4 +11,8 @@
 		<PackageReference Include="MySql.Data" Version="9.4.0" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <Folder Include="Pages\Technician - Copia\" />
+	</ItemGroup>
+
 </Project>

--- a/Fuerza_G_Taller/Models/Brand.cs
+++ b/Fuerza_G_Taller/Models/Brand.cs
@@ -6,7 +6,7 @@
         public string Name { get; set; } = string.Empty;
         public DateTime CreatedAt { get; set; }
         public DateTime? UpdatedAt { get; set; }
-        public bool IsActive { get; set; } = true;
+        public bool IsActive { get; set; }
         public int? ModifiedByUserId { get; set; }
     }
 }

--- a/Fuerza_G_Taller/Pages/Brand/Create.cshtml
+++ b/Fuerza_G_Taller/Pages/Brand/Create.cshtml
@@ -1,0 +1,17 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Brand.CreateModel
+@{
+    ViewData["Title"] = "Agregar Marca";
+}
+
+<h1>Agregar Marca</h1>
+
+<form method="post">
+    <div>
+        <label>Nombre:</label>
+        <input asp-for="Brand.Name" />
+    </div>
+    <button type="submit">Guardar</button>
+</form>
+
+<a asp-page="Index">Volver</a>

--- a/Fuerza_G_Taller/Pages/Brand/Create.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Brand/Create.cshtml.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Fuerza_G_Taller.Models;
+using BrandModel = Fuerza_G_Taller.Models.Brand;
+using Fuerza_G_Taller.Repositories;
+
+namespace Fuerza_G_Taller.Pages.Brand
+{
+    public class CreateModel : PageModel
+    {
+        private readonly BrandRepository _repository;
+
+        public CreateModel(BrandRepository repository)
+        {
+            _repository = repository;
+        }
+
+        [BindProperty]
+        public BrandModel Brand { get; set; } = new BrandModel();
+
+        public IActionResult OnPost()
+        {
+            if (!ModelState.IsValid) return Page();
+
+            _repository.Add(Brand);
+            return RedirectToPage("Index");
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Brand/Delete.cshtml
+++ b/Fuerza_G_Taller/Pages/Brand/Delete.cshtml
@@ -1,0 +1,14 @@
+﻿@page "{id:int}"
+@model Fuerza_G_Taller.Pages.Brand.DeleteModel
+@{
+    ViewData["Title"] = "Eliminar Marca";
+}
+
+<h1>Eliminar Marca</h1>
+
+<p>¿Seguro que quieres eliminar la marca: <strong>@Model.Brand.Name</strong>?</p>
+
+<form method="post">
+    <button type="submit">Sí, eliminar</button>
+    <a asp-page="Index">Cancelar</a>
+</form>

--- a/Fuerza_G_Taller/Pages/Brand/Delete.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Brand/Delete.cshtml.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Fuerza_G_Taller.Models;
+using BrandModel = Fuerza_G_Taller.Models.Brand;
+using Fuerza_G_Taller.Repositories;
+
+namespace Fuerza_G_Taller.Pages.Brand
+{
+    public class DeleteModel : PageModel
+    {
+        private readonly BrandRepository _repository;
+
+        public DeleteModel(BrandRepository repository)
+        {
+            _repository = repository;
+        }
+
+        [BindProperty]
+        public BrandModel Brand { get; set; } = new BrandModel();
+
+        public IActionResult OnGet(int id)
+        {
+            var brand = _repository.GetById(id);
+            if (brand == null) return RedirectToPage("Index");
+
+            Brand = brand;
+            return Page();
+        }
+
+        public IActionResult OnPost()
+        {
+            _repository.Delete(Brand.Id);
+            return RedirectToPage("Index");
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Brand/Edit.cshtml
+++ b/Fuerza_G_Taller/Pages/Brand/Edit.cshtml
@@ -1,0 +1,17 @@
+﻿@page "{id:int}"
+@model Fuerza_G_Taller.Pages.Brand.EditModel
+@{
+    ViewData["Title"] = "Editar Marca";
+}
+
+<h1>Editar Marca</h1>
+
+<form method="post">
+    <div>
+        <label>Nombre:</label>
+        <input asp-for="Brand.Name" />
+    </div>
+    <button type="submit">Guardar</button>
+</form>
+
+<a asp-page="Index">Volver</a>

--- a/Fuerza_G_Taller/Pages/Brand/Edit.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Brand/Edit.cshtml.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Fuerza_G_Taller.Models;
+using BrandModel = Fuerza_G_Taller.Models.Brand;
+using Fuerza_G_Taller.Repositories;
+
+namespace Fuerza_G_Taller.Pages.Brand
+{
+    public class EditModel : PageModel
+    {
+        private readonly BrandRepository _repository;
+
+        public EditModel(BrandRepository repository)
+        {
+            _repository = repository;
+        }
+
+        [BindProperty]
+        public BrandModel Brand { get; set; } = new BrandModel();
+
+
+        public IActionResult OnGet(int id)
+        {
+            var brand = _repository.GetById(id);
+            if (brand == null) return RedirectToPage("Index");
+
+            Brand = brand;
+            return Page();
+        }
+
+        public IActionResult OnPost()
+        {
+            if (!ModelState.IsValid) return Page();
+
+            _repository.Update(Brand);
+            return RedirectToPage("Index");
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Brand/Index.cshtml
+++ b/Fuerza_G_Taller/Pages/Brand/Index.cshtml
@@ -1,0 +1,32 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Brand.IndexModel
+@{
+    ViewData["Title"] = "Marcas";
+}
+
+<h1>Marcas</h1>
+
+<a asp-page="Create">Agregar Marca</a>
+
+<table>
+    <thead>
+        <tr>
+            <th>Id</th>
+            <th>Nombre</th>
+            <th>Acciones</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var brand in Model.Brands)
+        {
+            <tr>
+                <td>@brand.Id</td>
+                <td>@brand.Name</td>
+                <td>
+                    <a asp-page="Edit" asp-route-id="@brand.Id">Editar</a> |
+                    <a asp-page="Delete" asp-route-id="@brand.Id">Eliminar</a>
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>

--- a/Fuerza_G_Taller/Pages/Brand/Index.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Brand/Index.cshtml.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Fuerza_G_Taller.Models;
+using BrandModel = Fuerza_G_Taller.Models.Brand;
+using Fuerza_G_Taller.Repositories;
+
+namespace Fuerza_G_Taller.Pages.Brand
+{
+    public class IndexModel : PageModel
+    {
+        private readonly BrandRepository _repository;
+
+        public IndexModel(BrandRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public IEnumerable<BrandModel> Brands { get; set; } = new List<BrandModel>();
+
+        public void OnGet()
+        {
+            Brands = _repository.GetAll();
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Index.cshtml
+++ b/Fuerza_G_Taller/Pages/Index.cshtml
@@ -1,10 +1,11 @@
 ﻿@page
-@model IndexModel
+@model Fuerza_G_Taller.Pages.IndexModel
 @{
-    ViewData["Title"] = "Home page";
+    ViewData["Title"] = "Inicio";
 }
 
-<div class="text-center">
-    <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
-</div>
+<h1>Bienvenido a Fuerza G Taller</h1>
+
+<p>Este es el panel principal del sistema.</p>
+
+<a asp-page="/Login">Iniciar sesión</a>

--- a/Fuerza_G_Taller/Pages/Index.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Index.cshtml.cs
@@ -1,20 +1,12 @@
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Fuerza_G_Taller.Pages
 {
     public class IndexModel : PageModel
     {
-        private readonly ILogger<IndexModel> _logger;
-
-        public IndexModel(ILogger<IndexModel> logger)
-        {
-            _logger = logger;
-        }
-
         public void OnGet()
         {
-
+            // Aquí puedes pasar datos a la vista si es necesario
         }
     }
 }

--- a/Fuerza_G_Taller/Pages/Login.cshtml
+++ b/Fuerza_G_Taller/Pages/Login.cshtml
@@ -1,0 +1,21 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.LoginModel
+@{
+    ViewData["Title"] = "Login";
+}
+
+<h1>Iniciar Sesión</h1>
+
+<form method="post">
+    <div>
+        <label>Usuario:</label>
+        <input asp-for="Username" />
+    </div>
+    <div>
+        <label>Contraseña:</label>
+        <input asp-for="Password" type="password" />
+    </div>
+    <button type="submit">Entrar</button>
+</form>
+
+<p>@Model.ErrorMessage</p>

--- a/Fuerza_G_Taller/Pages/Login.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Login.cshtml.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages
+{
+    public class LoginModel : PageModel
+    {
+        [BindProperty]
+        public string Username { get; set; } = string.Empty;
+
+        [BindProperty]
+        public string Password { get; set; } = string.Empty;
+
+        public string ErrorMessage { get; set; } = string.Empty;
+
+        public void OnGet()
+        {
+            // Si quieres, aquí puedes limpiar sesiones previas
+        }
+
+        public IActionResult OnPost()
+        {
+            // Ejemplo simple de login (después se puede conectar a la base de datos)
+            if (Username == "admin" && Password == "0000")
+            {
+                // Redirigir al Home
+                return RedirectToPage("/Index");
+            }
+            else
+            {
+                ErrorMessage = "Usuario o contraseña incorrectos";
+                return Page();
+            }
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Model/Create.cshtml
+++ b/Fuerza_G_Taller/Pages/Model/Create.cshtml
@@ -1,0 +1,17 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Brand.CreateModel
+@{
+    ViewData["Title"] = "Agregar Marca";
+}
+
+<h1>Agregar Marca</h1>
+
+<form method="post">
+    <div>
+        <label>Nombre:</label>
+        <input asp-for="Brand.Name" />
+    </div>
+    <button type="submit">Guardar</button>
+</form>
+
+<a asp-page="Index">Volver</a>

--- a/Fuerza_G_Taller/Pages/Model/Create.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Model/Create.cshtml.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using ModelEntity = Fuerza_G_Taller.Models.Model;
+using Fuerza_G_Taller.Repositories;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class CreateModel : PageModel
+    {
+        private readonly ModelRepository _repository;
+        private readonly BrandRepository _brandRepository;
+
+        public CreateModel(ModelRepository repository, BrandRepository brandRepository)
+        {
+            _repository = repository;
+            _brandRepository = brandRepository;
+        }
+
+        [BindProperty]
+        public ModelEntity Model { get; set; } = new ModelEntity();
+
+        public IEnumerable<SelectListItem> BrandsSelectList { get; set; } = new List<SelectListItem>();
+
+        public void OnGet()
+        {
+            BrandsSelectList = _brandRepository.GetAll()
+                .Select(b => new SelectListItem { Value = b.Id.ToString(), Text = b.Name });
+        }
+
+        public IActionResult OnPost()
+        {
+            if (!ModelState.IsValid) return Page();
+
+            _repository.Add(Model);
+            return RedirectToPage("Index");
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Model/Delete.cshtml
+++ b/Fuerza_G_Taller/Pages/Model/Delete.cshtml
@@ -1,0 +1,14 @@
+﻿@page "{id:int}"
+@model Fuerza_G_Taller.Pages.Model.DeleteModel
+@{
+    ViewData["Title"] = "Eliminar Modelo";
+}
+
+<h1>Eliminar Modelo</h1>
+
+<p>¿Seguro que quieres eliminar el modelo: <strong>@Model.Model.Name</strong>?</p>
+
+<form method="post">
+    <button type="submit">Sí, eliminar</button>
+    <a asp-page="Index">Cancelar</a>
+</form>

--- a/Fuerza_G_Taller/Pages/Model/Delete.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Model/Delete.cshtml.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using ModelEntity = Fuerza_G_Taller.Models.Model;
+using Fuerza_G_Taller.Repositories;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class DeleteModel : PageModel
+    {
+        private readonly ModelRepository _repository;
+
+        public DeleteModel(ModelRepository repository)
+        {
+            _repository = repository;
+        }
+
+        [BindProperty]
+        public ModelEntity Model { get; set; } = new ModelEntity();
+
+        public IActionResult OnGet(int id)
+        {
+            var modelEntity = _repository.GetById(id);
+            if (modelEntity == null) return RedirectToPage("Index");
+
+            Model = modelEntity;
+            return Page();
+        }
+
+        public IActionResult OnPost()
+        {
+            _repository.Delete(Model.Id);
+            return RedirectToPage("Index");
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Model/Edit.cshtml
+++ b/Fuerza_G_Taller/Pages/Model/Edit.cshtml
@@ -1,0 +1,17 @@
+﻿@page "{id:int}"
+@model Fuerza_G_Taller.Pages.Brand.EditModel
+@{
+    ViewData["Title"] = "Editar Marca";
+}
+
+<h1>Editar Marca</h1>
+
+<form method="post">
+    <div>
+        <label>Nombre:</label>
+        <input asp-for="Brand.Name" />
+    </div>
+    <button type="submit">Guardar</button>
+</form>
+
+<a asp-page="Index">Volver</a>

--- a/Fuerza_G_Taller/Pages/Model/Edit.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Model/Edit.cshtml.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using ModelEntity = Fuerza_G_Taller.Models.Model;
+using Fuerza_G_Taller.Repositories;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class EditModel : PageModel
+    {
+        private readonly ModelRepository _repository;
+        private readonly BrandRepository _brandRepository;
+
+        public EditModel(ModelRepository repository, BrandRepository brandRepository)
+        {
+            _repository = repository;
+            _brandRepository = brandRepository;
+        }
+
+        [BindProperty]
+        public ModelEntity Model { get; set; } = new ModelEntity();
+
+        public IEnumerable<SelectListItem> BrandsSelectList { get; set; } = new List<SelectListItem>();
+
+        public IActionResult OnGet(int id)
+        {
+            var modelEntity = _repository.GetById(id);
+            if (modelEntity == null) return RedirectToPage("Index");
+
+            Model = modelEntity;
+
+            BrandsSelectList = _brandRepository.GetAll()
+                .Select(b => new SelectListItem { Value = b.Id.ToString(), Text = b.Name });
+
+            return Page();
+        }
+
+        public IActionResult OnPost()
+        {
+            if (!ModelState.IsValid) return Page();
+
+            _repository.Update(Model);
+            return RedirectToPage("Index");
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Model/Index.cshtml
+++ b/Fuerza_G_Taller/Pages/Model/Index.cshtml
@@ -1,0 +1,32 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Brand.IndexModel
+@{
+    ViewData["Title"] = "Marcas";
+}
+
+<h1>Marcas</h1>
+
+<a asp-page="Create">Agregar Marca</a>
+
+<table>
+    <thead>
+        <tr>
+            <th>Id</th>
+            <th>Nombre</th>
+            <th>Acciones</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var brandItem in Model.Brands)
+        {
+            <tr>
+                <td>@brandItem.Id</td>
+                <td>@brandItem.Name</td>
+                <td>
+                    <a asp-page="Edit" asp-route-id="@brandItem.Id">Editar</a> |
+                    <a asp-page="Delete" asp-route-id="@brandItem.Id">Eliminar</a>
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>

--- a/Fuerza_G_Taller/Pages/Model/Index.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Model/Index.cshtml.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using ModelEntity = Fuerza_G_Taller.Models.Model;
+using Fuerza_G_Taller.Repositories;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class IndexModel : PageModel
+    {
+        private readonly ModelRepository _repository;
+        private readonly BrandRepository _brandRepository;
+
+        public IndexModel(ModelRepository repository, BrandRepository brandRepository)
+        {
+            _repository = repository;
+            _brandRepository = brandRepository;
+        }
+
+        public List<ModelView> Models { get; set; } = new List<ModelView>();
+
+        public void OnGet()
+        {
+            var models = _repository.GetAll();
+            var brands = _brandRepository.GetAll().ToDictionary(b => b.Id, b => b.Name);
+
+            Models = models.Select(m => new ModelView
+            {
+                Id = m.Id,
+                Name = m.Name,
+                BrandId = m.BrandId,
+                BrandName = brands.ContainsKey(m.BrandId) ? brands[m.BrandId] : "N/A"
+            }).ToList();
+        }
+
+        public class ModelView
+        {
+            public int Id { get; set; }
+            public string Name { get; set; } = string.Empty;
+            public int BrandId { get; set; }
+            public string BrandName { get; set; } = string.Empty;
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Owner/Create.cshtml
+++ b/Fuerza_G_Taller/Pages/Owner/Create.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.CreateModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Owner/Create.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Owner/Create.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class CreateModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Owner/Delete.cshtml
+++ b/Fuerza_G_Taller/Pages/Owner/Delete.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.DeleteModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Owner/Delete.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Owner/Delete.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class DeleteModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Owner/Edit.cshtml
+++ b/Fuerza_G_Taller/Pages/Owner/Edit.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.EditModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Owner/Edit.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Owner/Edit.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class EditModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Owner/Index.cshtml
+++ b/Fuerza_G_Taller/Pages/Owner/Index.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.IndexModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Owner/Index.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Owner/Index.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class IndexModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Service/Create.cshtml
+++ b/Fuerza_G_Taller/Pages/Service/Create.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.CreateModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Service/Create.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Service/Create.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class CreateModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Service/Delete.cshtml
+++ b/Fuerza_G_Taller/Pages/Service/Delete.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.DeleteModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Service/Delete.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Service/Delete.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class DeleteModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Service/Edit.cshtml
+++ b/Fuerza_G_Taller/Pages/Service/Edit.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.EditModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Service/Edit.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Service/Edit.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class EditModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Service/Index.cshtml
+++ b/Fuerza_G_Taller/Pages/Service/Index.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.IndexModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Service/Index.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Service/Index.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class IndexModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Technician - Copia/Create.cshtml
+++ b/Fuerza_G_Taller/Pages/Technician - Copia/Create.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.CreateModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Technician - Copia/Create.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Technician - Copia/Create.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class CreateModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Technician - Copia/Delete.cshtml
+++ b/Fuerza_G_Taller/Pages/Technician - Copia/Delete.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.DeleteModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Technician - Copia/Delete.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Technician - Copia/Delete.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class DeleteModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Technician - Copia/Edit.cshtml
+++ b/Fuerza_G_Taller/Pages/Technician - Copia/Edit.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.EditModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Technician - Copia/Edit.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Technician - Copia/Edit.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class EditModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Technician - Copia/Index.cshtml
+++ b/Fuerza_G_Taller/Pages/Technician - Copia/Index.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.IndexModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Technician - Copia/Index.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Technician - Copia/Index.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class IndexModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Technician/Create.cshtml
+++ b/Fuerza_G_Taller/Pages/Technician/Create.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.CreateModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Technician/Create.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Technician/Create.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class CreateModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Technician/Delete.cshtml
+++ b/Fuerza_G_Taller/Pages/Technician/Delete.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.DeleteModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Technician/Delete.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Technician/Delete.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class DeleteModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Technician/Edit.cshtml
+++ b/Fuerza_G_Taller/Pages/Technician/Edit.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.EditModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Technician/Edit.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Technician/Edit.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class EditModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Technician/Index.cshtml
+++ b/Fuerza_G_Taller/Pages/Technician/Index.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.IndexModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Technician/Index.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Technician/Index.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class IndexModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Vehicle/Create.cshtml
+++ b/Fuerza_G_Taller/Pages/Vehicle/Create.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.CreateModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Vehicle/Create.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Vehicle/Create.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class CreateModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Vehicle/Delete.cshtml
+++ b/Fuerza_G_Taller/Pages/Vehicle/Delete.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.DeleteModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Vehicle/Delete.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Vehicle/Delete.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class DeleteModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Vehicle/Edit.cshtml
+++ b/Fuerza_G_Taller/Pages/Vehicle/Edit.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.EditModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Vehicle/Edit.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Vehicle/Edit.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class EditModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Fuerza_G_Taller/Pages/Vehicle/Index.cshtml
+++ b/Fuerza_G_Taller/Pages/Vehicle/Index.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model Fuerza_G_Taller.Pages.Model.IndexModel
+@{
+}

--- a/Fuerza_G_Taller/Pages/Vehicle/Index.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Vehicle/Index.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Fuerza_G_Taller.Pages.Model
+{
+    public class IndexModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}


### PR DESCRIPTION
Este PR agrega las páginas Razor completas para la gestión de Brand y Model en el proyecto:

- CRUD de Brand: Index, Create, Edit y Delete
- CRUD de Model: Index, Create, Edit y Delete
- Inyección de BrandRepository y ModelRepository para acceso a datos
- Dropdown de marcas en Create/Edit de Model
- Variables claras en Razor para evitar conflictos con 'Model'
- Compatible con la arquitectura existente de repositorios y singleton de base de datos

Con este PR se habilita la gestión completa de marcas y modelos desde la interfaz web.
