### PR TITLE
feat(pages): agregar páginas CRUD completas para Owner

### DIFF
--- a/Fuerza_G_Taller/Pages/Owner/Create.cshtml
+++ b/Fuerza_G_Taller/Pages/Owner/Create.cshtml
@@ -1,4 +1,41 @@
 ﻿@page
-@model Fuerza_G_Taller.Pages.Model.CreateModel
+@model Fuerza_G_Taller.Pages.Owner.CreateModel
 @{
+    ViewData["Title"] = "Agregar Propietario";
 }
+
+<h1>Agregar Propietario</h1>
+
+<form method="post">
+    <div>
+        <label>Nombre:</label>
+        <input asp-for="Owner.Name" />
+    </div>
+    <div>
+        <label>Primer Apellido:</label>
+        <input asp-for="Owner.FirstLastName" />
+    </div>
+    <div>
+        <label>Segundo Apellido:</label>
+        <input asp-for="Owner.SecondLastName" />
+    </div>
+    <div>
+        <label>Teléfono:</label>
+        <input asp-for="Owner.PhoneNumber" />
+    </div>
+    <div>
+        <label>Email:</label>
+        <input asp-for="Owner.Email" />
+    </div>
+    <div>
+        <label>Documento:</label>
+        <input asp-for="Owner.DocumentNumber" />
+    </div>
+    <div>
+        <label>Dirección:</label>
+        <input asp-for="Owner.Address" />
+    </div>
+    <button type="submit">Guardar</button>
+</form>
+
+<a asp-page="Index">Volver</a>

--- a/Fuerza_G_Taller/Pages/Owner/Create.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Owner/Create.cshtml.cs
@@ -1,12 +1,33 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using OwnerEntity = Fuerza_G_Taller.Models.Owner;
+using Fuerza_G_Taller.Repositories;
 
-namespace Fuerza_G_Taller.Pages.Model
+namespace Fuerza_G_Taller.Pages.Owner
 {
     public class CreateModel : PageModel
     {
-        public void OnGet()
+        private readonly OwnerRepository _repository;
+
+        public CreateModel(OwnerRepository repository)
         {
+            _repository = repository;
+        }
+
+        [BindProperty]
+        public OwnerEntity Owner { get; set; } = new OwnerEntity();
+
+        public IActionResult OnGet()
+        {
+            return Page();
+        }
+
+        public IActionResult OnPost()
+        {
+            if (!ModelState.IsValid) return Page();
+
+            _repository.Add(Owner);
+            return RedirectToPage("Index");
         }
     }
 }

--- a/Fuerza_G_Taller/Pages/Owner/Delete.cshtml
+++ b/Fuerza_G_Taller/Pages/Owner/Delete.cshtml
@@ -1,4 +1,14 @@
-﻿@page
-@model Fuerza_G_Taller.Pages.Model.DeleteModel
+﻿@page "{id:int}"
+@model Fuerza_G_Taller.Pages.Owner.DeleteModel
 @{
+    ViewData["Title"] = "Eliminar Propietario";
 }
+
+<h1>Eliminar Propietario</h1>
+
+<p>¿Seguro que quieres eliminar al propietario: <strong>@Model.Owner.Name @Model.Owner.FirstLastName</strong>?</p>
+
+<form method="post">
+    <button type="submit">Sí, eliminar</button>
+    <a asp-page="Index">Cancelar</a>
+</form>

--- a/Fuerza_G_Taller/Pages/Owner/Delete.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Owner/Delete.cshtml.cs
@@ -1,12 +1,35 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using OwnerEntity = Fuerza_G_Taller.Models.Owner;
+using Fuerza_G_Taller.Repositories;
 
-namespace Fuerza_G_Taller.Pages.Model
+namespace Fuerza_G_Taller.Pages.Owner
 {
     public class DeleteModel : PageModel
     {
-        public void OnGet()
+        private readonly OwnerRepository _repository;
+
+        public DeleteModel(OwnerRepository repository)
         {
+            _repository = repository;
+        }
+
+        [BindProperty]
+        public OwnerEntity Owner { get; set; } = new OwnerEntity();
+
+        public IActionResult OnGet(int id)
+        {
+            var ownerEntity = _repository.GetById(id);
+            if (ownerEntity == null) return RedirectToPage("Index");
+
+            Owner = ownerEntity;
+            return Page();
+        }
+
+        public IActionResult OnPost()
+        {
+            _repository.Delete(Owner.Id);
+            return RedirectToPage("Index");
         }
     }
 }

--- a/Fuerza_G_Taller/Pages/Owner/Edit.cshtml
+++ b/Fuerza_G_Taller/Pages/Owner/Edit.cshtml
@@ -1,4 +1,41 @@
-﻿@page
-@model Fuerza_G_Taller.Pages.Model.EditModel
+﻿@page "{id:int}"
+@model Fuerza_G_Taller.Pages.Owner.EditModel
 @{
+    ViewData["Title"] = "Editar Propietario";
 }
+
+<h1>Editar Propietario</h1>
+
+<form method="post">
+    <div>
+        <label>Nombre:</label>
+        <input asp-for="Owner.Name" />
+    </div>
+    <div>
+        <label>Primer Apellido:</label>
+        <input asp-for="Owner.FirstLastName" />
+    </div>
+    <div>
+        <label>Segundo Apellido:</label>
+        <input asp-for="Owner.SecondLastName" />
+    </div>
+    <div>
+        <label>Teléfono:</label>
+        <input asp-for="Owner.PhoneNumber" />
+    </div>
+    <div>
+        <label>Email:</label>
+        <input asp-for="Owner.Email" />
+    </div>
+    <div>
+        <label>Documento:</label>
+        <input asp-for="Owner.DocumentNumber" />
+    </div>
+    <div>
+        <label>Dirección:</label>
+        <input asp-for="Owner.Address" />
+    </div>
+    <button type="submit">Guardar</button>
+</form>
+
+<a asp-page="Index">Volver</a>

--- a/Fuerza_G_Taller/Pages/Owner/Edit.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Owner/Edit.cshtml.cs
@@ -1,12 +1,37 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using OwnerEntity = Fuerza_G_Taller.Models.Owner;
+using Fuerza_G_Taller.Repositories;
 
-namespace Fuerza_G_Taller.Pages.Model
+namespace Fuerza_G_Taller.Pages.Owner
 {
     public class EditModel : PageModel
     {
-        public void OnGet()
+        private readonly OwnerRepository _repository;
+
+        public EditModel(OwnerRepository repository)
         {
+            _repository = repository;
+        }
+
+        [BindProperty]
+        public OwnerEntity Owner { get; set; } = new OwnerEntity();
+
+        public IActionResult OnGet(int id)
+        {
+            var ownerEntity = _repository.GetById(id);
+            if (ownerEntity == null) return RedirectToPage("Index");
+
+            Owner = ownerEntity;
+            return Page();
+        }
+
+        public IActionResult OnPost()
+        {
+            if (!ModelState.IsValid) return Page();
+
+            _repository.Update(Owner);
+            return RedirectToPage("Index");
         }
     }
 }

--- a/Fuerza_G_Taller/Pages/Owner/Index.cshtml
+++ b/Fuerza_G_Taller/Pages/Owner/Index.cshtml
@@ -1,4 +1,44 @@
 ﻿@page
-@model Fuerza_G_Taller.Pages.Model.IndexModel
+@model Fuerza_G_Taller.Pages.Owner.IndexModel
 @{
+    ViewData["Title"] = "Propietarios";
 }
+
+<h1>Propietarios</h1>
+
+<a asp-page="Create">Agregar Propietario</a>
+
+<table>
+    <thead>
+        <tr>
+            <th>Id</th>
+            <th>Nombre</th>
+            <th>Primer Apellido</th>
+            <th>Segundo Apellido</th>
+            <th>Teléfono</th>
+            <th>Email</th>
+            <th>Documento</th>
+            <th>Dirección</th>
+            <th>Acciones</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var ownerItem in Model.Owners)
+        {
+            <tr>
+                <td>@ownerItem.Id</td>
+                <td>@ownerItem.Name</td>
+                <td>@ownerItem.FirstLastName</td>
+                <td>@ownerItem.SecondLastName</td>
+                <td>@ownerItem.PhoneNumber</td>
+                <td>@ownerItem.Email</td>
+                <td>@ownerItem.DocumentNumber</td>
+                <td>@ownerItem.Address</td>
+                <td>
+                    <a asp-page="Edit" asp-route-id="@ownerItem.Id">Editar</a> |
+                    <a asp-page="Delete" asp-route-id="@ownerItem.Id">Eliminar</a>
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>

--- a/Fuerza_G_Taller/Pages/Owner/Index.cshtml.cs
+++ b/Fuerza_G_Taller/Pages/Owner/Index.cshtml.cs
@@ -1,12 +1,23 @@
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using OwnerEntity = Fuerza_G_Taller.Models.Owner;
+using Fuerza_G_Taller.Repositories;
 
-namespace Fuerza_G_Taller.Pages.Model
+namespace Fuerza_G_Taller.Pages.Owner
 {
     public class IndexModel : PageModel
     {
+        private readonly OwnerRepository _repository;
+
+        public IndexModel(OwnerRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public IEnumerable<OwnerEntity> Owners { get; set; } = new List<OwnerEntity>();
+
         public void OnGet()
         {
+            Owners = _repository.GetAll();
         }
     }
 }


### PR DESCRIPTION
feat(pages): agregar páginas CRUD completas para Owner

Se implementan las páginas Razor de Owner incluyendo:
- Index, Create, Edit y Delete
- Uso de OwnerRepository con inyección de dependencias
- Variables claras en Razor para evitar conflictos con 'Model'
- Compatible con la arquitectura existente de repositorios y singleton de base de datos